### PR TITLE
Change path

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,6 +16,6 @@ Download using the [GitHub .zip download](https://github.com/getomni/alacritty/a
 2. Edit the Alacritty config file by adding:
 ```yaml
 import:
-  - ./omni.yml
+  - /omni.yml
 ```
 3. Alacritty reloads the config automagically

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,6 +16,6 @@ Download using the [GitHub .zip download](https://github.com/getomni/alacritty/a
 2. Edit the Alacritty config file by adding:
 ```yaml
 import:
-  - /omni.yml
+  - ~/.config/alacritty/omni.yml
 ```
 3. Alacritty reloads the config automagically


### PR DESCRIPTION
**Changes proposed**
In step 1 of activate theme, it says that you must copy omni.yml in the ~ directory, but when we try to follow the step 2 it does't work because the path on the import is incorrect. It indicate that this file is a directory.